### PR TITLE
Add FAQ pack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ This SSDT injects the audio `layout-id` directly via ACPI, replacing the need fo
 
 🎯 Tip: Use Hackintool or IORegistryExplorer to verify if the injection was applied.
 
+## 📚 FAQ & Additional Resources
+
+For a deeper look at audio injection on Clover versus OpenCore, check out the
+[Hackintosh Audio Injection FAQ Pack](./Hackintosh_FAQ_Audio_Complete_Pack).
+It contains FAQs in English and Portuguese, example ACPI patches and an
+SSDT configured for `layout-id` 13.
+
 ---
 
 Created by: Hackintosh and Beyond


### PR DESCRIPTION
## Summary
- add links to `Hackintosh_FAQ_Audio_Complete_Pack` from README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861ea82159c83289ffb83318a402588

## Summary by Sourcery

Documentation:
- Add a new FAQ & Additional Resources section pointing to the Hackintosh Audio Injection FAQ Pack